### PR TITLE
Appdata files now refer to real tilp and gfm desktop files

### DIFF
--- a/gfm/trunk/configure.ac
+++ b/gfm/trunk/configure.ac
@@ -77,6 +77,7 @@ AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
+AC_C_RESTRICT
 AC_HEADER_STAT
 AC_TYPE_UID_T
 AC_TYPE_MODE_T

--- a/gfm/trunk/desktop/gfm.appdata.xml
+++ b/gfm/trunk/desktop/gfm.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2015 Ben Rosser <rosser.bjr@gmail.com> -->
 <application>
-	<id type="desktop">comical.desktop</id>
+	<id type="desktop">gfm.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-2.0+</project_license>
 	<name>Group File Manager</name>

--- a/tilp/trunk/configure.ac
+++ b/tilp/trunk/configure.ac
@@ -95,6 +95,7 @@ AC_CHECK_HEADERS([stdlib.h string.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
+AC_C_RESTRICT
 AC_HEADER_STAT
 AC_TYPE_UID_T
 AC_TYPE_MODE_T

--- a/tilp/trunk/desktop/tilp.appdata.xml
+++ b/tilp/trunk/desktop/tilp.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2015 Ben Rosser <rosser.bjr@gmail.com> -->
 <application>
-	<id type="desktop">comical.desktop</id>
+	<id type="desktop">tilp.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-2.0+</project_license>
 	<name>TILP2</name>


### PR DESCRIPTION
Apparently, it seems that the appdata files still pass basic validation even if the referenced desktop file doesn't exist, which seems like a bug in appstream-utils...

Anyway, this commit fixes a rather silly issue where my appdata files both referred to the dummy "comical.desktop" rather than the real tilp and gfm desktop files. This went unnoticed in Fedora review at the time (and for a long while afterwards), but was recently caught by a manual check of which packages' appdata wasn't being processed properly. 