### PR TITLE
cmake: improve LDFLAGS setting and fix build issues for macOS 10.15

### DIFF
--- a/gfm/trunk/CMakeLists.txt
+++ b/gfm/trunk/CMakeLists.txt
@@ -25,7 +25,8 @@ set(SRC_FILES
 add_executable(gfm ${SRC_FILES})
 
 # External deps
-pkg_check_modules(DEPS REQUIRED glib-2.0 ticonv tifiles2 ticalcs2)
+pkg_check_modules(DEPS REQUIRED gtk+-2.0 glib-2.0 ticonv tifiles2 ticalcs2)
+string(REPLACE ";" " " DEPS_LDFLAGS "${DEPS_LDFLAGS}")
 find_package(Iconv REQUIRED)
 find_package(GTK2 REQUIRED gtk glade)
 
@@ -39,8 +40,8 @@ target_include_directories(gfm PRIVATE src ${GTK2_INCLUDE_DIRS})
 
 # Link-related properties, flags...
 link_directories(${DEPS_LIBRARY_DIRS})
-target_link_libraries(gfm "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES} ${GTK2_LIBRARIES} ${Iconv_LIBRARIES} ${Intl_LIBRARIES})
-set_target_properties(gfm PROPERTIES LINK_FLAGS "-rdynamic")  # Needed for the GUI callback functions
+target_link_libraries(gfm ${DEPS_LIBRARIES} ${GTK2_LIBRARIES} ${Iconv_LIBRARIES} ${Intl_LIBRARIES})
+set_target_properties(gfm PROPERTIES LINK_FLAGS "${DEPS_LDFLAGS} -rdynamic")  # rdynamic is needed for the GUI callback functions
 
 # Takes care of the i18n po/pot/gmo/mo files
 i18n_mo_from_po_pot()

--- a/tilp/trunk/CMakeLists.txt
+++ b/tilp/trunk/CMakeLists.txt
@@ -52,7 +52,8 @@ set(SRC_FILES
 add_executable(tilp2 ${SRC_FILES})
 
 # External deps
-pkg_check_modules(DEPS REQUIRED glib-2.0 ticonv tifiles2 ticables2 ticalcs2 zlib)
+pkg_check_modules(DEPS REQUIRED gtk+-2.0 glib-2.0 ticonv tifiles2 ticables2 ticalcs2 zlib)
+string(REPLACE ";" " " DEPS_LDFLAGS "${DEPS_LDFLAGS}")
 find_package(Iconv REQUIRED)
 find_package(GTK2 REQUIRED gtk)
 
@@ -66,8 +67,8 @@ target_include_directories(tilp2 PRIVATE src ${GTK2_INCLUDE_DIRS})
 
 # Link-related properties, flags...
 link_directories(${DEPS_LIBRARY_DIRS})
-target_link_libraries(tilp2 "${DEPS_LDFLAGS}" ${DEPS_LIBRARIES} ${GTK2_LIBRARIES} ${Iconv_LIBRARIES} ${Intl_LIBRARIES})
-set_target_properties(tilp2 PROPERTIES LINK_FLAGS "-rdynamic")  # Needed for the GUI callback functions
+target_link_libraries(tilp2 ${DEPS_LIBRARIES} ${GTK2_LIBRARIES} ${Iconv_LIBRARIES} ${Intl_LIBRARIES})
+set_target_properties(tilp2 PROPERTIES LINK_FLAGS "${DEPS_LDFLAGS} -rdynamic")  # rdynamic is needed for the GUI callback functions
 
 # Takes care of the i18n po/pot/gmo/mo files
 i18n_mo_from_po_pot()


### PR DESCRIPTION
- Adding gtk+-2.0 as deps with pkg-config solves some build issues (harfbuzz missing include dir, at the very least) on macOS 10.15
- Pass DEPS_LDFLAGS correctly with PROPERTIES LINK_FLAGS

Note that because pkg_check_modules seems to use ";" as seps instead of leaving spaces sometimes, it breaks some stuff like "-framework Cocoa" on macOS, so we replace ";" by " " manually, and make sure to pass the LDFLAGS quoted.