### PR TITLE
Let Git ignore more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ Session.vim
 
 # CMake
 cmake-build-*/
+/build/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ missing
 stamp-h?
 **/po/POTFILES
 **/po/stamp-po
+**/po/*.pot
 
 .deps/
 .dirstamp


### PR DESCRIPTION
### gitignore pot files
    
Ignore:
    
- gfm/trunk/po/GFM.pot
- tilp/trunk/po/tilp2.pot

### gitignore cmake /build/ folder
    
Ignore build/ folder in repository root,
don't ignore build/ subdirectories.