### PR TITLE
List TI-82+, TI-83+.fr non-USB, and fix TI-83.fr USB name as TI-83+.fr

### DIFF
--- a/tilp/trunk/builder/device.ui
+++ b/tilp/trunk/builder/device.ui
@@ -106,7 +106,7 @@
         <col id="1" translatable="no">ti83</col>
       </row>
       <row>
-        <col id="0" translatable="yes">TI-83+</col>
+        <col id="0" translatable="yes">TI-83+(.fr) / TI-82+</col>
         <col id="1" translatable="no">ti83+</col>
       </row>
       <row>

--- a/tilp/trunk/builder/device.ui
+++ b/tilp/trunk/builder/device.ui
@@ -110,7 +110,7 @@
         <col id="1" translatable="no">ti83+</col>
       </row>
       <row>
-        <col id="0" translatable="yes">TI-84+ / TI-83.fr USB</col>
+        <col id="0" translatable="yes">TI-84+ / TI-83+.fr USB</col>
         <col id="1" translatable="no">ti84+</col>
       </row>
       <row>


### PR DESCRIPTION
### tilp: also list TI-82+ and TI-83+.fr (non USB)
    
There exist two non-USB French TI-83+ calculators:
    
- TI-83+.fr (non USB), which is blue,
- TI-82+, which is white.

### tilp: fix TI-83.fr USB name as TI-83+.fr USB