### PR TITLE
fix duplicate global symbol

### DIFF
--- a/tilp/trunk/src/tilp_update.c
+++ b/tilp/trunk/src/tilp_update.c
@@ -27,7 +27,7 @@
 
 #include "tilp_core.h"
 
-extern CalcUpdate	default_update;
+static CalcUpdate	default_update;
 
 static void default_start(void)
 {
@@ -82,7 +82,7 @@ static void default_refresh(void)
 {
 }
 
-CalcUpdate default_update =
+static CalcUpdate default_update =
 {
 	"", 0,
 	0.0, 0, 0, 0, 0, 0, 0, (1 << 0), 0,


### PR DESCRIPTION
Conflicts with [this](https://github.com/debrouxl/tilibs/blob/c9d377e3ef2af8f435f62896b3f859c1365d7a59/libticalcs/trunk/src/update.cc#L30).