### PR TITLE
tilp: Use g_get_user_config_dir() to get the config directory

### DIFF
--- a/tilp/trunk/src/tilp_config.c
+++ b/tilp/trunk/src/tilp_config.c
@@ -102,90 +102,68 @@ int tilp_config_default(void)
 	return 0;
 }
 
+static void deprecated_config_path(char* old_ini_file, char* ini_file)
+{
+	int old_exists, new_exists;
+	old_exists = !access(old_ini_file, F_OK);
+	new_exists = !access(ini_file, F_OK);
+
+	if (old_exists && !new_exists)
+	{
+		FILE *in;
+		FILE *out;
+
+		in = fopen(old_ini_file, "rb");
+		out = fopen(ini_file, "wb");
+		if (in && out)
+		{
+			int c;
+			while ((c = fgetc(in)) != EOF)
+			{
+				fputc(c, out);
+			}
+			fclose(out);
+			fclose(in);
+			// A config file now exists at the new location.
+			// Delete the old file.
+			unlink(old_ini_file);
+		}
+	}
+}
+
 static char * get_config_path(void)
 {
-	return g_strconcat(g_get_home_dir(), G_DIR_SEPARATOR_S, INI_FILE, NULL);
+	return g_build_path(G_DIR_SEPARATOR_S, g_get_user_config_dir(), "tilp.ini", NULL);
 }
+
+#if defined(__LINUX__) || defined(__BSD__) || defined(__MACOSX__)
+# define OLD_INI_FILE  "tilp"
+#elif defined(__WIN32__)
+# define OLD_INI_FILE  "tilp.ini"
+#endif
 
 /* Chech whether a RC file exists */
 int tilp_config_exist(void)
 {
-#if defined(__LINUX__) || defined(__BSD__) || defined(__MACOSX__)
-	char * ini_file;
 	int retval;
+	char * ini_file;
+	char* old_ini_file;
+	old_ini_file = g_strconcat(g_get_home_dir(), G_DIR_SEPARATOR_S, OLD_INI_FILE, NULL);
+	deprecated_config_path(old_ini_file, ini_file);
+	free(old_ini_file);
 
 	ini_file = get_config_path();
-
+#if defined(__WIN32__)
+	// On Windows, there can be two config files:
+	// * per-user config files (which the *nix versions have been using for ages).
+	// * in the install dir (deprecated, as it does not work well with the UAC);
+	old_ini_file = g_strconcat(inst_paths.base_dir, G_DIR_SEPARATOR_S, OLD_INI_FILE, NULL);
+	deprecated_config_path(old_ini_file, ini_file);
+	g_free(old_ini_file);
+#endif
 	retval = !access(ini_file, F_OK);
 	g_free(ini_file);
 	return retval;
-#elif defined(__WIN32__)
-	char* old_ini_file;
-	char* ini_file;
-	int result1, result2, retval;
-
-	// On Windows, there can be two config files:
-	// * in the install dir (deprecated, as it does not work well with the UAC);
-	old_ini_file = g_strconcat(inst_paths.base_dir, G_DIR_SEPARATOR_S, INI_FILE, NULL);
-	result1 = !access(old_ini_file, F_OK);
-	// * per-user config files (which the *nix versions have been using for ages).
-	ini_file = get_config_path();
-	result2 = !access(ini_file, F_OK);
-
-	if (result1)
-	{
-		// A config file exists at the old location
-		if (!result2)
-		{
-			// No config file exists at the new location, bad.
-			// Create it.
-			FILE *in;
-			FILE *out;
-
-			in = fopen(old_ini_file, "rb");
-			out = fopen(ini_file, "wb");
-			if (in && out)
-			{
-				int c;
-
-				while ((c = fgetc(in)) != EOF)
-				{
-					fputc(c, out);
-				}
-				fclose(out);
-				fclose(in);
-				// A config file now exists at the new location.
-				// Delete the old file.
-				unlink(old_ini_file);
-				retval = 1;
-			}
-			else
-			{
-				// There's a problem...
-				// Trigger failure in the callers.
-				retval = 0;
-			}
-		}
-		else
-		{
-			// A config file exists at the new location (even if a config file exists at the old location), good.
-			retval = 1;
-		}
-	}
-	else if (result2)
-	{
-		// A config file exists at the new location, good.
-		retval = 1;
-	}
-	else
-	{
-		// No config file at either location.
-		retval = 0;
-	}
-	g_free(old_ini_file);
-	g_free(ini_file);
-	return retval;
-#endif
 }
 
 

--- a/tilp/trunk/src/tilp_config.c
+++ b/tilp/trunk/src/tilp_config.c
@@ -149,10 +149,10 @@ int tilp_config_exist(void)
 	char * ini_file;
 	char* old_ini_file;
 	old_ini_file = g_strconcat(g_get_home_dir(), G_DIR_SEPARATOR_S, OLD_INI_FILE, NULL);
+	ini_file = get_config_path();
 	deprecated_config_path(old_ini_file, ini_file);
 	free(old_ini_file);
 
-	ini_file = get_config_path();
 #if defined(__WIN32__)
 	// On Windows, there can be two config files:
 	// * per-user config files (which the *nix versions have been using for ages).

--- a/tilp/trunk/src/tilp_paths.h
+++ b/tilp/trunk/src/tilp_paths.h
@@ -28,13 +28,6 @@
 
 #include <stdio.h>
 
-/* Paths */
-#if defined(__LINUX__) || defined(__BSD__) || defined(__MACOSX__)
-# define INI_FILE  "/.tilp"
-#elif defined(__WIN32__)
-# define INI_FILE  "tilp.ini"
-#endif
-
 /* Temporary filenames (used by cb_calc.c) */
 #define TMPFILE_BACKUP   "tilp.backup"
 #define TMPFILE_ROMDUMP  "tilp.romdump"


### PR DESCRIPTION
This allows the XDG base specification to be followed, defaulting to LocalAppData on windows.

It also deprecates the old config path, using the same logic as the Windows deprecated config (which has been extracted to a helper).